### PR TITLE
Patch default init script on Ubuntu to allow reading syslog files

### DIFF
--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -9,17 +9,6 @@ logstash-pkg:
     - require:
       - pkgrepo: logstash-repo
 
-logstash-svc:
-  service.running:
-    - name: {{logstash.svc}}
-    - enable: true
-    - require:
-      - pkg: logstash-pkg
-    - watch:
-      - file: logstash-config-inputs
-      - file: logstash-config-filters
-      - file: logstash-config-outputs
-
 # This gets around a user permissions bug with the logstash user/group
 # being able to read /var/log/syslog, even if the group is properly set for
 # the account. The group needs to be defined as 'adm' in the init script,
@@ -31,7 +20,20 @@ change service group in Ubuntu init script:
     - name: /etc/init.d/logstash
     - pattern: "LS_GROUP=logstash"
     - repl: "LS_GROUP=adm"
+    - watch_in:
+      - service: logstash-svc
 {%- endif %}
+
+logstash-svc:
+  service.running:
+    - name: {{logstash.svc}}
+    - enable: true
+    - require:
+      - pkg: logstash-pkg
+    - watch:
+      - file: logstash-config-inputs
+      - file: logstash-config-filters
+      - file: logstash-config-outputs
 
 {%- if logstash.inputs is defined %}
 logstash-config-inputs:

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -24,17 +24,6 @@ change service group in Ubuntu init script:
       - service: logstash-svc
 {%- endif %}
 
-logstash-svc:
-  service.running:
-    - name: {{logstash.svc}}
-    - enable: true
-    - require:
-      - pkg: logstash-pkg
-    - watch:
-      - file: logstash-config-inputs
-      - file: logstash-config-filters
-      - file: logstash-config-outputs
-
 {%- if logstash.inputs is defined %}
 logstash-config-inputs:
   file.managed:
@@ -85,3 +74,14 @@ logstash-config-outputs:
   file.absent:
     - name: /etc/logstash/conf.d/03-outputs.conf
 {%- endif %}
+
+logstash-svc:
+  service.running:
+    - name: {{logstash.svc}}
+    - enable: true
+    - require:
+      - pkg: logstash-pkg
+    - watch:
+      - file: logstash-config-inputs
+      - file: logstash-config-filters
+      - file: logstash-config-outputs

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -20,6 +20,19 @@ logstash-svc:
       - file: logstash-config-filters
       - file: logstash-config-outputs
 
+# This gets around a user permissions bug with the logstash user/group
+# being able to read /var/log/syslog, even if the group is properly set for
+# the account. The group needs to be defined as 'adm' in the init script,
+# so we'll do a pattern replace.
+
+{%- if salt['grains.get']('os', None) == "Ubuntu" %}
+change service group in Ubuntu init script:
+  file.replace:
+    - name: /etc/init.d/logstash
+    - pattern: "LS_GROUP=logstash"
+    - repl: "LS_GROUP=adm"
+{%- endif %}
+
 {%- if logstash.inputs is defined %}
 logstash-config-inputs:
   file.managed:

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -22,6 +22,15 @@ change service group in Ubuntu init script:
     - repl: "LS_GROUP=adm"
     - watch_in:
       - service: logstash-svc
+
+add adm group to logstash service account:
+  user.present:
+    - name: logstash
+    - groups:
+      - logstash
+      - adm
+    - require:
+      - pkg: logstash-pkg
 {%- endif %}
 
 {%- if logstash.inputs is defined %}


### PR DESCRIPTION
This adds two extra states for Ubuntu systems to allow logstash to be able to read `/var/log/syslog` (and other files that grant read access the the `adm` group).

It does two things:

1. Use `file.replace` to change the `LS_GROUP` variable to `adm` in `/etc/init.d/logstash`.
2. Use `user.managed` to make sure the `logstash` service account is actually a member of the `adm` group.

Patching the init file is necessary even if the group is properly added, since the init script still launches the service as the `logstash` group.