### PR TITLE
Free the configuration layout

### DIFF
--- a/logstash/files/01-inputs.conf
+++ b/logstash/files/01-inputs.conf
@@ -1,2 +1,0 @@
-{%- from 'logstash/map.jinja' import logstash,format_logstash_config with context -%}
-{{ format_logstash_config('input', logstash.inputs) }}

--- a/logstash/files/02-filters.conf
+++ b/logstash/files/02-filters.conf
@@ -1,2 +1,0 @@
-{%- from 'logstash/map.jinja' import logstash,format_logstash_config with context -%}
-{{ format_logstash_config('filter', logstash.filters) }}

--- a/logstash/files/03-outputs.conf
+++ b/logstash/files/03-outputs.conf
@@ -1,2 +1,0 @@
-{%- from 'logstash/map.jinja' import logstash,format_logstash_config with context -%}
-{{ format_logstash_config('output', logstash.outputs) }}

--- a/logstash/files/conf
+++ b/logstash/files/conf
@@ -1,0 +1,4 @@
+{%- from 'logstash/map.jinja' import logstash, format_logstash_config with context -%}
+{%- for plugin_type, plugin_array in logstash.conf[conf_name].iteritems() -%}
+{{ format_logstash_config(plugin_type, plugin_array) }}
+{%- endfor -%}

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -33,64 +33,32 @@ add adm group to logstash service account:
       - pkg: logstash-pkg
 {%- endif %}
 
-{%- if logstash.inputs is defined %}
-logstash-config-inputs:
+{%- for conf_name in logstash.conf.keys() %}
+{{'/'.join([logstash.conf_dir, conf_name + '.conf'])}}:
   file.managed:
-    - name: /etc/logstash/conf.d/01-inputs.conf
     - user: root
     - group: root
     - mode: 755
-    - source: salt://logstash/files/01-inputs.conf
+    - source: salt://logstash/files/conf
     - template: jinja
+    - defaults:
+        conf_name: {{conf_name}}
     - require:
       - pkg: logstash-pkg
-{%- else %}
-logstash-config-inputs:
-  file.absent:
-    - name: /etc/logstash/conf.d/01-inputs.conf
-{%- endif %}
+    - require_in:
+      - file: logstash-config
+    - watch_in:
+      - service: logstash-svc
+{%- endfor %}
 
-{%- if logstash.filters is defined %}
-logstash-config-filters:
-  file.managed:
-    - name: /etc/logstash/conf.d/02-filters.conf
-    - user: root
-    - group: root
-    - mode: 755
-    - source: salt://logstash/files/02-filters.conf
-    - template: jinja
-    - require:
-      - pkg: logstash-pkg
-{%- else %}
-logstash-config-filters:
-  file.absent:
-    - name: /etc/logstash/conf.d/02-filters.conf
-{%- endif %}
-
-{%- if logstash.outputs is defined %}
-logstash-config-outputs:
-  file.managed:
-    - name: /etc/logstash/conf.d/03-outputs.conf
-    - user: root
-    - group: root
-    - mode: 755
-    - source: salt://logstash/files/03-outputs.conf
-    - template: jinja
-    - require:
-      - pkg: logstash-pkg
-{%- else %}
-logstash-config-outputs:
-  file.absent:
-    - name: /etc/logstash/conf.d/03-outputs.conf
-{%- endif %}
+logstash-config:
+  file.directory:
+    - name: {{logstash.conf_dir}}
+    - clean: True
 
 logstash-svc:
   service.running:
     - name: {{logstash.svc}}
     - enable: true
-    - require:
-      - pkg: logstash-pkg
     - watch:
-      - file: logstash-config-inputs
-      - file: logstash-config-filters
-      - file: logstash-config-outputs
+      - file: logstash-config

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -3,13 +3,15 @@
     'pkg': 'logstash',
     'svc': 'logstash',
     'pkgstate': 'latest',
-    'indent': 4
+    'indent': 4,
+    'conf_dir': '/etc/logstash/conf.d'
   },
   'RedHat': {
     'pkg': 'logstash',
     'svc': 'logstash',
     'pkgstate': 'latest',
-    'indent': 4
+    'indent': 4,
+    'conf_dir': '/etc/logstash/conf.d'
   }
 }, merge=salt['pillar.get']('logstash')) %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,39 +1,43 @@
 ---
 logstash:
-  inputs:
-    - 
-      plugin_name: file
-      path:
-        - /var/log/syslog
-        - /var/log/auth.log
-      type: syslog
-  filters:
-    -
-      plugin_name: grok
-      cond: 'if [type] == "syslog"'
-      match:
-        message: '%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}'
-      add_field:
-        received_at: '%{@timestamp}'
-        received_from: '%{host}'
-    -
-      plugin_name: grok
-      cond: 'else if [type] == "nginx"'
-      match:
-        message: '%{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] \"(?:%{WORD:verb} %{URIPATHPARAM:request}(?: HTTP/%{NUMBER:httpversion})?|-)\" %{NUMBER:response} (?:%{NUMBER:bytes}|-) \"(?:%{URI:referrer}|-)\" %{QS:agent}'
-      add_field:
-        received_at: '%{@timestamp}'
-        received_from: '%{host}'        
-    -
-      plugin_name: date
-      match:
-        - 'syslog_timestamp'
-        - 'MMM  d HH:mm:ss'
-        - 'MMM dd HH:mm:ss'
-  outputs:
-    -
-      plugin_name: lumberjack
-      hosts:
-        - logs.example.com
-      port: 5000
-      ssl_certificate: /etc/ssl/certs/lumberjack.crt
+  conf:
+    01-inputs:
+      inputs:
+        -
+          plugin_name: file
+          path:
+            - /var/log/syslog
+            - /var/log/auth.log
+          type: syslog
+    02-filters:
+      filters:
+        -
+          plugin_name: grok
+          cond: 'if [type] == "syslog"'
+          match:
+            message: '%{SYSLOGTIMESTAMP:syslog_timestamp} %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?: %{GREEDYDATA:syslog_message}'
+          add_field:
+            received_at: '%{@timestamp}'
+            received_from: '%{host}'
+        -
+          plugin_name: grok
+          cond: 'else if [type] == "nginx"'
+          match:
+            message: '%{IPORHOST:clientip} %{USER:ident} %{USER:auth} \[%{HTTPDATE:timestamp}\] \"(?:%{WORD:verb} %{URIPATHPARAM:request}(?: HTTP/%{NUMBER:httpversion})?|-)\" %{NUMBER:response} (?:%{NUMBER:bytes}|-) \"(?:%{URI:referrer}|-)\" %{QS:agent}'
+          add_field:
+            received_at: '%{@timestamp}'
+            received_from: '%{host}'
+        -
+          plugin_name: date
+          match:
+            - 'syslog_timestamp'
+            - 'MMM  d HH:mm:ss'
+            - 'MMM dd HH:mm:ss'
+    03-outputs:
+      outputs:
+        -
+          plugin_name: lumberjack
+          hosts:
+            - logs.example.com
+          port: 5000
+          ssl_certificate: /etc/ssl/certs/lumberjack.crt


### PR DESCRIPTION
Hi,

This pull request aims to let the user choose the Logstash configuration layout. Indeed, one might want to stack Logstash configuration files as traits (e.g. `10-syslog.conf`, `10-custom-input.conf`, `20-custom-filter.conf`) as the Pillar + `top.sls` structure allows it. The current layout (i.e. `01-inputs.conf`, `02-filters.conf`, `03-outputs.conf`) is too much static and sticks the user to defining a Logstash configuration per host.

Note that this change breaks backward compatibility.

Still to be done: updating the README section "Pillar Data Explained"