### PR TITLE
Logstash 2.0 compatability, plugin install functionality and env configuration

### DIFF
--- a/logstash/files/default
+++ b/logstash/files/default
@@ -1,0 +1,3 @@
+{% for k,v in config.items() %}
+{{ k }}={{ v }}
+{% endfor %}

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -94,7 +94,7 @@ logstash-config-outputs:
 {% if logstash.env is defined %}
 logstash-env:
   file.managed:
-    - name: /etc/default/logstash.conf
+    - name: /etc/default/logstash
     - mode: 664
     - user: root
     - group: root
@@ -103,7 +103,7 @@ logstash-env:
     - require:
       - pkg: logstash-pkg
     - defaults:
-      config: {{ logstash.env }}
+      config: {{ logstash.env | json }}
 {% endif %}
 
 logstash-svc:

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -8,9 +8,10 @@
 
 include:
   - .repo
+  - .plugin
 
 logstash-pkg:
-  pkg.{{logstash.pkgstate}}:
+  pkg.{{ logstash.pkgstate }}:
     - name: {{logstash.pkg}}
     - version: {{ versionstring }}
     - require:

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -7,8 +7,8 @@
 {% endif %}
 
 include:
-  - .repo
-  - .plugin
+  - logstash.repo
+  - logstash.plugin
 
 logstash-pkg:
   pkg.{{ logstash.pkgstate }}:

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -3,13 +3,15 @@
     'pkg': 'logstash',
     'svc': 'logstash',
     'pkgstate': 'latest',
-    'indent': 4
+    'indent': 4,
+    'version': 1.4
   },
   'RedHat': {
     'pkg': 'logstash',
     'svc': 'logstash',
     'pkgstate': 'latest',
-    'indent': 4
+    'indent': 4,
+    'version': 1.4
   }
 }, merge=salt['pillar.get']('logstash')) %}
 

--- a/logstash/plugin.sls
+++ b/logstash/plugin.sls
@@ -1,0 +1,22 @@
+{%- from 'logstash/map.jinja' import logstash with context %}
+
+{% if logstash.plugin_install %}
+{% if logstash.version.startswith('2') %}
+{% for plugin in logstash.plugin_install %}
+logstash_plugin_{{ plugin.name }}:
+  cmd.run:
+    - name: /opt/logstash/bin/plugin install --version {{ plugin.version }} {{ plugin.name }}
+    - creates: /opt/logstash/vendor/bundle/jruby/1.9/gems/{{ plugin.name }}-{{ plugin.version }}
+    - require:
+      - pkg: logstash
+{% endfor %}
+{% endif %}
+{% endif %}
+
+extend:
+  logstash:
+    service:
+      - watch:
+{% for plugin in logstash.plugin_install %}
+        - cmd: logstash_plugin_{{ plugin.name }}
+{% endfor %}

--- a/logstash/repo.sls
+++ b/logstash/repo.sls
@@ -1,3 +1,8 @@
+{%- from 'logstash/map.jinja' import logstash with context %}
+
+{% set splitversion = logstash.version.split('.') %}
+{% set repoversion = splitversion[0] + "." + splitversion[1] %}
+
 {%- if grains['os_family'] == 'Debian' %}
 logstash-repo-key:
   cmd.run:
@@ -6,8 +11,8 @@ logstash-repo-key:
 
 logstash-repo:
   pkgrepo.managed:
-    - humanname: Logstash Debian Repository
-    - name: deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
+    - humanname: Logstash Debian Repository for logstash version {{ repoversion }}.x
+    - name: deb http://packages.elasticsearch.org/logstash/{{ repoversion }}/debian stable main
     - require:
       - cmd: logstash-repo-key
 {%- elif grains['os_family'] == 'RedHat' %}
@@ -18,8 +23,8 @@ logstash-repo-key:
 
 logstash-repo:
   pkgrepo.managed:
-    - humanname: logstash repository for 1.4.x packages
-    - baseurl: http://packages.elasticsearch.org/logstash/1.4/centos
+    - humanname: logstash repository for {{ repoversion }}.x packages
+    - baseurl: http://packages.elasticsearch.org/logstash/{{ repoversion }}/centos
     - gpgcheck: 1
     - gpgkey: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
     - enabled: 1

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,6 @@
 ---
 logstash:
+  version: 2.0
   inputs:
     - 
       plugin_name: file

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,12 @@
 ---
 logstash:
   version: 2.0
+  env:
+    KILL_ON_STOP_TIMEOUT: 0
+    LS_HEAP_SIZE: {{ ((grains.mem_total|int) /10*5)| round | int }}m
+  plugin_install:
+    - name: logstash-filter-de_dot
+      version: 0.1.1
   inputs:
     - 
       plugin_name: file


### PR DESCRIPTION
Managed to add somewhat forward compatibility for logstash 2.0.
The default version is set to 1.4 and a version identifier can now be defined, based on which repositories are added and packages installed. However, this is only tested on Ubuntu - so I'd be glad if someone could test on redhat.

This also adds functionality to install plugins through the logstash 2.0 plugin tool.

Last but not least, this will let you manage environment variables like LS_HEAP_SIZE in the /etc/default/logstash file.
