### PR TITLE
Update the repo state functions and LS version

### DIFF
--- a/logstash/repo.sls
+++ b/logstash/repo.sls
@@ -1,28 +1,16 @@
 {%- if grains['os_family'] == 'Debian' %}
-logstash-repo-key:
-  cmd.run:
-    - name: wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch | apt-key add -
-    - unless: apt-key list | grep 'Elasticsearch (Elasticsearch Signing Key)'
-
 logstash-repo:
   pkgrepo.managed:
     - humanname: Logstash Debian Repository for 2.1.x packages
-    - name: deb http://packages.elasticsearch.org/logstash/2.1/debian stable main
-    - require:
-      - cmd: logstash-repo-key
+    - name: deb http://packages.elastic.co/logstash/2.1/debian stable main
+    - gpgcheck: 1
+    - key_url: https://packages.elastic.co/GPG-KEY-elasticsearch
 {%- elif grains['os_family'] == 'RedHat' %}
-logstash-repo-key:
-  cmd.run:
-    - name:  rpm --import http://packages.elasticsearch.org/GPG-KEY-elasticsearch
-    - unless: rpm -qi gpg-pubkey-d88e42b4-52371eca
-
 logstash-repo:
   pkgrepo.managed:
     - humanname: logstash repository for 2.1.x packages
-    - baseurl: http://packages.elasticsearch.org/logstash/2.1/centos
+    - baseurl: http://packages.elastic.co/logstash/2.1/centos
     - gpgcheck: 1
-    - gpgkey: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
+    - gpgkey: http://packages.elastic.co/GPG-KEY-elasticsearch
     - enabled: 1
-    - require:
-      - cmd: logstash-repo-key
 {%- endif %}


### PR DESCRIPTION
Simplify using key_url in the state to handle the gpg keys.

Update logstash version to 2.1

Change repo url to elastic.co. And update to latest version.

Update gpgkey url.

Change to elastic.co domain.