### PR TITLE
Revert "[OPS-114] point formula to logtsash 2.1 repo"

### DIFF
--- a/logstash/repo.sls
+++ b/logstash/repo.sls
@@ -6,8 +6,8 @@ logstash-repo-key:
 
 logstash-repo:
   pkgrepo.managed:
-    - humanname: Logstash Debian Repository for 2.1.x packages
-    - name: deb http://packages.elasticsearch.org/logstash/2.1/debian stable main
+    - humanname: Logstash Debian Repository
+    - name: deb http://packages.elasticsearch.org/logstash/1.4/debian stable main
     - require:
       - cmd: logstash-repo-key
 {%- elif grains['os_family'] == 'RedHat' %}
@@ -18,8 +18,8 @@ logstash-repo-key:
 
 logstash-repo:
   pkgrepo.managed:
-    - humanname: logstash repository for 2.1.x packages
-    - baseurl: http://packages.elasticsearch.org/logstash/2.1/centos
+    - humanname: logstash repository for 1.4.x packages
+    - baseurl: http://packages.elasticsearch.org/logstash/1.4/centos
     - gpgcheck: 1
     - gpgkey: http://packages.elasticsearch.org/GPG-KEY-elasticsearch
     - enabled: 1


### PR DESCRIPTION
Reverts saltstack-formulas/logstash-formula#13

This revert is to undo #13 which was intended to target a fork of this repository NOT this repo as a stop gap measure as the community waits for #12 to drop. :disappointed:  The discussion around having the formula was done internally via Slack and was supposed to be merged elsewhere. This should fix any conflicts with #12.