### PR TITLE
Configurable Repositories, Split state into it's own containers, Fixed OS detection

### DIFF
--- a/logstash/config.sls
+++ b/logstash/config.sls
@@ -5,7 +5,7 @@
 # the account. The group needs to be defined as 'adm' in the init script,
 # so we'll do a pattern replace.
 
-{%- if salt['grains.get']('os', None) == "Ubuntu" %}
+{%- if salt['grains.get']('os_family', None) == "Debian" %}
 change service group in Ubuntu init script:
   file.replace:
     - name: /etc/init.d/logstash
@@ -27,7 +27,7 @@ add adm group to logstash service account:
 {%- if logstash.inputs is defined %}
 logstash-config-inputs:
   file.managed:
-    - name: /etc/logstash/conf.d/01-inputs.conf
+    - name: {{logstash.configdir}}conf.d/01-inputs.conf
     - user: root
     - group: root
     - mode: 755
@@ -38,13 +38,13 @@ logstash-config-inputs:
 {%- else %}
 logstash-config-inputs:
   file.absent:
-    - name: /etc/logstash/conf.d/01-inputs.conf
+    - name: {{logstash.configdir}}conf.d/01-inputs.conf
 {%- endif %}
 
 {%- if logstash.filters is defined %}
 logstash-config-filters:
   file.managed:
-    - name: /etc/logstash/conf.d/02-filters.conf
+    - name: {{logstash.configdir}}conf.d/02-filters.conf
     - user: root
     - group: root
     - mode: 755
@@ -55,13 +55,13 @@ logstash-config-filters:
 {%- else %}
 logstash-config-filters:
   file.absent:
-    - name: /etc/logstash/conf.d/02-filters.conf
+    - name: {{logstash.configdir}}conf.d/02-filters.conf
 {%- endif %}
 
 {%- if logstash.outputs is defined %}
 logstash-config-outputs:
   file.managed:
-    - name: /etc/logstash/conf.d/03-outputs.conf
+    - name: {{logstash.configdir}}conf.d/03-outputs.conf
     - user: root
     - group: root
     - mode: 755
@@ -72,5 +72,5 @@ logstash-config-outputs:
 {%- else %}
 logstash-config-outputs:
   file.absent:
-    - name: /etc/logstash/conf.d/03-outputs.conf
+    - name: {{logstash.configdir}}conf.d/03-outputs.conf
 {%- endif %}

--- a/logstash/config.sls
+++ b/logstash/config.sls
@@ -1,0 +1,76 @@
+{%- from 'logstash/map.jinja' import logstash with context %}
+
+# This gets around a user permissions bug with the logstash user/group
+# being able to read /var/log/syslog, even if the group is properly set for
+# the account. The group needs to be defined as 'adm' in the init script,
+# so we'll do a pattern replace.
+
+{%- if salt['grains.get']('os', None) == "Ubuntu" %}
+change service group in Ubuntu init script:
+  file.replace:
+    - name: /etc/init.d/logstash
+    - pattern: "LS_GROUP=logstash"
+    - repl: "LS_GROUP=adm"
+    - watch_in:
+      - service: logstash-svc
+
+add adm group to logstash service account:
+  user.present:
+    - name: logstash
+    - groups:
+      - logstash
+      - adm
+    - require:
+      - pkg: logstash-pkg
+{%- endif %}
+
+{%- if logstash.inputs is defined %}
+logstash-config-inputs:
+  file.managed:
+    - name: /etc/logstash/conf.d/01-inputs.conf
+    - user: root
+    - group: root
+    - mode: 755
+    - source: salt://logstash/files/01-inputs.conf
+    - template: jinja
+    - require:
+      - pkg: logstash-pkg
+{%- else %}
+logstash-config-inputs:
+  file.absent:
+    - name: /etc/logstash/conf.d/01-inputs.conf
+{%- endif %}
+
+{%- if logstash.filters is defined %}
+logstash-config-filters:
+  file.managed:
+    - name: /etc/logstash/conf.d/02-filters.conf
+    - user: root
+    - group: root
+    - mode: 755
+    - source: salt://logstash/files/02-filters.conf
+    - template: jinja
+    - require:
+      - pkg: logstash-pkg
+{%- else %}
+logstash-config-filters:
+  file.absent:
+    - name: /etc/logstash/conf.d/02-filters.conf
+{%- endif %}
+
+{%- if logstash.outputs is defined %}
+logstash-config-outputs:
+  file.managed:
+    - name: /etc/logstash/conf.d/03-outputs.conf
+    - user: root
+    - group: root
+    - mode: 755
+    - source: salt://logstash/files/03-outputs.conf
+    - template: jinja
+    - require:
+      - pkg: logstash-pkg
+{%- else %}
+logstash-config-outputs:
+  file.absent:
+    - name: /etc/logstash/conf.d/03-outputs.conf
+{%- endif %}

--- a/logstash/defaults.yaml
+++ b/logstash/defaults.yaml
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+logstash:
+  pkg: "logstash"
+  svc: "logstash"
+  pkgstate: "latest"
+  indent: 4
+  repoversion: "2.3"
+  configfile: "/etc/logstash/logstash.conf"
+  service:
+    name: logstash

--- a/logstash/defaults.yaml
+++ b/logstash/defaults.yaml
@@ -2,6 +2,7 @@
 # vim: ft=yaml
 logstash:
   pkg: "logstash"
+  javapkg: default-jre-headless
   svc: "logstash"
   pkgstate: "latest"
   indent: 4

--- a/logstash/defaults.yaml
+++ b/logstash/defaults.yaml
@@ -7,5 +7,6 @@ logstash:
   indent: 4
   repoversion: "2.3"
   configfile: "/etc/logstash/logstash.conf"
+  configdir: "/etc/logstash/"
   service:
     name: logstash

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -1,96 +1,11 @@
 {%- from 'logstash/map.jinja' import logstash with context %}
 
+# This is more like a meta-state that installs, configures and starts Logstash.
+# You can use this if you don't really want to change anything about the states.
+# It's also a lot cleaner to just have - logstash in your top.sls
+
 include:
   - .repo
-
-logstash-pkg:
-  pkg.{{logstash.pkgstate}}:
-    - name: {{logstash.pkg}}
-    - require:
-      - pkgrepo: logstash-repo
-
-# This gets around a user permissions bug with the logstash user/group
-# being able to read /var/log/syslog, even if the group is properly set for
-# the account. The group needs to be defined as 'adm' in the init script,
-# so we'll do a pattern replace.
-
-{%- if salt['grains.get']('os', None) == "Ubuntu" %}
-change service group in Ubuntu init script:
-  file.replace:
-    - name: /etc/init.d/logstash
-    - pattern: "LS_GROUP=logstash"
-    - repl: "LS_GROUP=adm"
-    - watch_in:
-      - service: logstash-svc
-
-add adm group to logstash service account:
-  user.present:
-    - name: logstash
-    - groups:
-      - logstash
-      - adm
-    - require:
-      - pkg: logstash-pkg
-{%- endif %}
-
-{%- if logstash.inputs is defined %}
-logstash-config-inputs:
-  file.managed:
-    - name: /etc/logstash/conf.d/01-inputs.conf
-    - user: root
-    - group: root
-    - mode: 755
-    - source: salt://logstash/files/01-inputs.conf
-    - template: jinja
-    - require:
-      - pkg: logstash-pkg
-{%- else %}
-logstash-config-inputs:
-  file.absent:
-    - name: /etc/logstash/conf.d/01-inputs.conf
-{%- endif %}
-
-{%- if logstash.filters is defined %}
-logstash-config-filters:
-  file.managed:
-    - name: /etc/logstash/conf.d/02-filters.conf
-    - user: root
-    - group: root
-    - mode: 755
-    - source: salt://logstash/files/02-filters.conf
-    - template: jinja
-    - require:
-      - pkg: logstash-pkg
-{%- else %}
-logstash-config-filters:
-  file.absent:
-    - name: /etc/logstash/conf.d/02-filters.conf
-{%- endif %}
-
-{%- if logstash.outputs is defined %}
-logstash-config-outputs:
-  file.managed:
-    - name: /etc/logstash/conf.d/03-outputs.conf
-    - user: root
-    - group: root
-    - mode: 755
-    - source: salt://logstash/files/03-outputs.conf
-    - template: jinja
-    - require:
-      - pkg: logstash-pkg
-{%- else %}
-logstash-config-outputs:
-  file.absent:
-    - name: /etc/logstash/conf.d/03-outputs.conf
-{%- endif %}
-
-logstash-svc:
-  service.running:
-    - name: {{logstash.svc}}
-    - enable: true
-    - require:
-      - pkg: logstash-pkg
-    - watch:
-      - file: logstash-config-inputs
-      - file: logstash-config-filters
-      - file: logstash-config-outputs
+  - .install
+  - .config
+  - .service

--- a/logstash/install.sls
+++ b/logstash/install.sls
@@ -1,0 +1,5 @@
+{%- from 'logstash/map.jinja' import logstash with context %}
+
+logstash-pkg:
+  pkg.{{logstash.pkgstate}}:
+    - name: {{logstash.pkg}}

--- a/logstash/java.sls
+++ b/logstash/java.sls
@@ -1,0 +1,5 @@
+{%- from 'logstash/map.jinja' import logstash with context %}
+
+logstash-java-pkg-requirement:
+  pkg.installed:
+    - name: {{logstash.javapkg}}

--- a/logstash/map.jinja
+++ b/logstash/map.jinja
@@ -1,17 +1,33 @@
-{% set logstash = salt['grains.filter_by']({
-  'Debian': {
-    'pkg': 'logstash',
-    'svc': 'logstash',
-    'pkgstate': 'latest',
-    'indent': 4
-  },
-  'RedHat': {
-    'pkg': 'logstash',
-    'svc': 'logstash',
-    'pkgstate': 'latest',
-    'indent': 4
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
+{## Start with  defaults from defaults.yaml ##}
+{% import_yaml 'logstash/defaults.yaml' as default_settings %}
+
+{##
+Setup variable using grains['os_family'] based logic, only add key:values here
+that differ from whats in defaults.yaml
+##}
+{% set os_family_map = salt['grains.filter_by']({
+        'Debian': {},
+        'Suse': {},
+        'Arch': {},
+        'RedHat': {},
   }
-}, merge=salt['pillar.get']('logstash')) %}
+  , grain="os_family"
+  , merge=salt['pillar.get']('logstash:lookup'))
+%}
+{## Merge the flavor_map to the default settings ##}
+{% do default_settings.logstash.update(os_family_map) %}
+
+{## Merge in logstash:lookup pillar ##}
+{% set logstash = salt['pillar.get'](
+        'logstash',
+        default=default_settings.logstash,
+        merge=True
+    )
+%}
+
 
 {%- macro output_indented(col, string) %}
 {{ string|indent(col, true) -}}

--- a/logstash/repo.sls
+++ b/logstash/repo.sls
@@ -1,7 +1,7 @@
 {%- from 'logstash/map.jinja' import logstash with context %}
 
 {%- if grains['os_family'] == 'Debian' %}
-beats_repo_https_apt_support:
+logstash_repo_https_apt_support:
   pkg.installed:
     - name: apt-transport-https
 

--- a/logstash/repo.sls
+++ b/logstash/repo.sls
@@ -5,7 +5,7 @@ beats_repo_https_apt_support:
   pkg.installed:
     - name: apt-transport-https
 
-logstash_repo:
+logstash-repo:
   pkgrepo.managed:
     - humanname: Logstash Repo
     - name: deb https://packages.elastic.co/logstash/{{logstash.repoversion}}/debian stable main

--- a/logstash/service.sls
+++ b/logstash/service.sls
@@ -1,0 +1,12 @@
+{%- from 'logstash/map.jinja' import logstash with context %}
+
+logstash-svc:
+  service.running:
+    - name: {{logstash.svc}}
+    - enable: true
+    - require:
+      - pkg: logstash-pkg
+    - watch:
+      - file: logstash-config-inputs
+      - file: logstash-config-filters
+      - file: logstash-config-outputs


### PR DESCRIPTION
A few things are fixed now:
- Proper map.jinja and defaults.yaml interaction
- Configurable version for the repository so you can install newer versions
- Configurable configuration directory in case you want to use a custom logstash but still manage it
- OS detection, select based on Debian as a family so Debian and Ubuntu are both fixed regarding the adm group (so logstash can actually access the logs)
