### PR TITLE
Javapkg dependencies

### DIFF
--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -8,11 +8,11 @@ include:
 logstash-pkg:
   pkg.{{logstash.pkgstate}}:
     - name: {{logstash.pkg}}
-    {%- if logstash.use_upstream_repo %}
     - require:
-      - pkgrepo: logstash-repo
       - pkg: logstash-javapkg
-    {%- endif %}
+      {%- if logstash.use_upstream_repo %}
+      - pkgrepo: logstash-repo
+      {%- endif %}
 
 logstash-javapkg:
   pkg.installed:

--- a/logstash/init.sls
+++ b/logstash/init.sls
@@ -11,11 +11,12 @@ logstash-pkg:
     {%- if logstash.use_upstream_repo %}
     - require:
       - pkgrepo: logstash-repo
-      - pkg: {{ logstash.java }}
+      - pkg: logstash-javapkg
     {%- endif %}
 
-{{ logstash.java }}:
-  pkg.installed
+logstash-javapkg:
+  pkg.installed:
+  - name: {{ logstash.java }}
 
 # This gets around a user permissions bug with the logstash user/group
 # being able to read /var/log/syslog, even if the group is properly set for


### PR DESCRIPTION
Fix dependencies:
* Always install, means it should always depend...
* Specific state-id, to avoid conflict dependencies with other states